### PR TITLE
Add Gradle Tasks extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "eamodio.gitlens",
         "ms-vscode.go",
         "naco-siren.gradle-language",
+        "richardwillis.vscode-gradle",
         "wholroyd.hcl",
         "github.vscode-pull-request-github",
         "qezhu.gitlink",


### PR DESCRIPTION
This extension adds functionality to view and run Gradle Tasks and can be useful for working with Gradle projects.

Extension: https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-gradle