### PR TITLE
Replaced Jsonnet with Jsonnet Language Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "qezhu.gitlink",
         "ivory-lab.jenkinsfile-support",
         "eriklynd.json-tools",
-        "heptio.jsonnet",
+        "Grafana.vscode-jsonnet",
         "ms-kubernetes-tools.vscode-kubernetes-tools",
         "ipedrazas.kubernetes-snippets",
         "randomchance.logstash",


### PR DESCRIPTION
This heptio.jsonnet extension is deprecated as it is no longer being maintained so replaced it with grafana.vscode-jsonnet which has Full code support (formatting, highlighting, navigation, etc) for Jsonnet